### PR TITLE
Add referer and IP check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mservice-mapproxy
+service-mapproxy
 ================
 
 Mapproxy configuration and service for 'geo.admin.ch'!

--- a/apache/referer-check.conf
+++ b/apache/referer-check.conf
@@ -9,7 +9,10 @@ SetEnvIF X-FORWARDED-FOR ^162.23.164.245$ GOODIP # AppGate BIT
 SetEnvIF X-FORWARDED-FOR ^162.23.164.246$ GOODIP # AppGate BIT
 
 # we may set additional referers, but for now it is good enough
-SetEnvIF Referer "^(?i)http(s)?://([^./]*\.)*geo\.admin\.ch"  GOODREFERER
+SetEnvIF Referer "^(?i)http(s)?://([^./]*\.)*geo\.admin\.ch"                    GOODREFERER
+SetEnvIF Referer "^(?i)http(s)?://([^./]*\.)*(dev|int|prod|demo|ci)\.bgdi\.ch"  GOODREFERER
+SetEnvIF Referer "^(?i)http(s)?://localhost"                                    GOODREFERER
+
 
 # ELB Health check!
 SetEnvIf Request_URI "^/$" GOODIP

--- a/apache/referer-check.conf
+++ b/apache/referer-check.conf
@@ -1,0 +1,23 @@
+SetEnvIF X-FORWARDED-FOR ^193.5.216.100$  GOODIP # swisstopo gateway
+SetEnvIF X-FORWARDED-FOR ^193.5.216.70$   GOODIP # swisstopo gateway
+SetEnvIF X-FORWARDED-FOR ^128.179.66.4$   GOODIP # camptocamp CH gateway
+SetEnvIF X-FORWARDED-FOR ^81.18.187.187$  GOODIP # camptocamp FR gateway 1
+SetEnvIF X-FORWARDED-FOR ^81.18.187.188$  GOODIP # camptocamp FR gateway 2
+SetEnvIF X-FORWARDED-FOR ^162.23.164.249$ GOODIP # AppGate BIT
+SetEnvIF X-FORWARDED-FOR ^162.23.164.250$ GOODIP # AppGate BIT
+SetEnvIF X-FORWARDED-FOR ^162.23.164.245$ GOODIP # AppGate BIT
+SetEnvIF X-FORWARDED-FOR ^162.23.164.246$ GOODIP # AppGate BIT
+
+# we may set additional referers, but for now it is good enough
+SetEnvIF Referer "^(?i)http(s)?://([^./]*\.)*geo\.admin\.ch"  GOODREFERER
+
+RewriteCond %{REQUEST_URI} /checker/ [NC]
+RewriteCond %{ENV:GOODIP} =1
+RewriteRule ^(.*)$ - [QSA,L]
+
+<Location />
+   Order Deny,Allow
+   Deny from all
+   Allow from env=GOODIP
+   Allow from env=GOODREFERER
+</Location>

--- a/apache/referer-check.conf
+++ b/apache/referer-check.conf
@@ -11,9 +11,9 @@ SetEnvIF X-FORWARDED-FOR ^162.23.164.246$ GOODIP # AppGate BIT
 # we may set additional referers, but for now it is good enough
 SetEnvIF Referer "^(?i)http(s)?://([^./]*\.)*geo\.admin\.ch"  GOODREFERER
 
-RewriteCond %{REQUEST_URI} /checker/ [NC]
-RewriteCond %{ENV:GOODIP} =1
-RewriteRule ^(.*)$ - [QSA,L]
+# ELB Health check!
+SetEnvIf Request_URI "^/$" GOODIP
+
 
 <Location />
    Order Deny,Allow


### PR DESCRIPTION
If no default vhosts is present, service-mapproxy '/' is served by mapproxy. So the ELB health check is effectively checking the applicaiton itself.