### PR TITLE
Using Python system site modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ APACHE_BASE_PATH ?= /$(shell id -un)
 APACHE_BASE_DIRECTORY ?= $(CURDIR)
 MODWSGI_USER ?= $(shell id -un)
 API_URL ?= http://api3.geo.admin.ch
+PYTHONVENV_OPTS ?= --system-site-packages
 
 
 ## Python interpreter can't have space in path name
@@ -29,6 +30,7 @@ help:
 	@echo "- APACHE_BASE_PATH Base path  (current value: $(APACHE_BASE_PATH))"
 	@echo "- APACHE_BASE_DIRECTORY       (current value: $(APACHE_BASE_DIRECTORY))"
 	@echo "- API_URL                     (current value: $(API_URL))"
+	@echo "- PYTHONVENV_OPTS             (current value: $(PYTHONVENV_OPTS))"
 	@echo
 
 
@@ -56,7 +58,7 @@ uwsgi: .build-artefacts/python-venv/bin/uwsgi
 
 .build-artefacts/python-venv:
 	mkdir -p .build-artefacts
-	virtualenv --no-site-packages $@
+	virtualenv ${PYTHONVENV_OPTS}  $@
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ help:
 	@echo "- mapproxy         Install and configure mapproxy"
 	@echo "- config           Configure mapproxy (mapproxy.yaml)"
 	@echo "- apache           Configure Apache (restart required)"
+	@echo "- uwsgi            Install uwsgi"
 	@echo "- clean            Remove generated files"
 	@echo "- help             Display this help"
 	@echo
@@ -50,6 +51,9 @@ mapproxy: .build-artefacts/python-venv/bin/mapproxy \
 	mapproxy/wsgi.py \
 	mapproxy.ini
 
+.PHONY: uwsgi
+uwsgi: .build-artefacts/python-venv/bin/uwsgi
+
 .build-artefacts/python-venv:
 	mkdir -p .build-artefacts
 	virtualenv --no-site-packages $@
@@ -65,10 +69,13 @@ mapproxy: .build-artefacts/python-venv/bin/mapproxy \
 	cp scripts/cmd.py .build-artefacts/python-venv/local/lib/python2.7/site-packages/mako/cmd.py
 
 .build-artefacts/python-venv/bin/mapproxy: .build-artefacts/python-venv
-	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install -e "git://github.com/procrastinatio/mapproxy.git@s3#egg=mapproxy"
-	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install "uwsgi==2.0.11"
+	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install  -e "git://github.com/procrastinatio/mapproxy.git@s3#egg=mapproxy"
 	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install "webob"
 	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install "httplib2==0.9.2"
+	touch $@
+
+.build-artefacts/python-venv/bin/uwsgi: .build-artefacts/python-venv
+	${PYTHON_CMD} .build-artefacts/python-venv/bin/pip install "uwsgi==2.0.11"
 	touch $@
 
 apache/app.conf: apache/app.mako-dot-conf 

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ mapproxy.ini:  mapproxy-dot-ini
 	    --var "apache_base_path=$(APACHE_BASE_PATH)"  $< > $@
 
 .PHONY: clean
-clean: clean
+clean:
 	rm -rf .build-artefacts
 	rm mapproxy.ini
 	rm apache/app.conf


### PR DESCRIPTION
...by default, to speed up the installation of Mapproxy.

Note: when you merge, it is directly used by the new instance in the mapproxy autoscaling group
