### PR TITLE
Using non default service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ API_URL ?= http://api3.geo.admin.ch
 PYTHONVENV ?= .build-artefacts/python-venv
 PYTHONVENV_OPTS ?= 
 WMTS_BASE_URL ?= http://wmts6.geo.admin.ch
-MAPPROXY_CONFIG_BASE_PATH ?= 
+MAPPROXY_CONFIG_BASE_PATH ?=swisstopo-internal-filesharing/config/mapproxy 
 export WMTS_BASE_URL
 
 

--- a/mapproxy/scripts/mapproxify.py
+++ b/mapproxy/scripts/mapproxify.py
@@ -421,7 +421,7 @@ def main(service_url=DEFAULT_SERVICE_URL,
     if topics is None:
         topics = getTopics(service_url=service_url)
 
-    layers_nb, timestamps_nb, layersConfig = getLayersConfigs(topics=topics)
+    layers_nb, timestamps_nb, layersConfig = getLayersConfigs(service_url=service_url, topics=topics)
 
     mapproxy_config = generate_mapproxy_config(layersConfig, services=services)
 


### PR DESCRIPTION
- Effectively using non produciton service for YAML generation.
- Default path for mapproxy.yaml upload to S3