### PR TITLE
Mom fix mismatch tiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help:
 	@echo "- PYTHONVENV_OPTS                   (current value: $(PYTHONVENV_OPTS))"
 	@echo "- WMTS_BASE_URL Source for tiles    (current value: $(WMTS_BASE_URL))"
 	@echo "- MAPPROXY_BUCKET_NAME              (current value: $(MAPPROXY_BUCKET_NAME))"
-	@echo "- MAPPROXY_CONFIG_BASE_PATH         (current value: $(MAPPROXY_CONFIG_BAS_PATH))"
+	@echo "- MAPPROXY_CONFIG_BASE_PATH         (current value: $(MAPPROXY_CONFIG_BASE_PATH))"
 	@echo
 
 

--- a/mapproxy/scripts/mapproxify.py
+++ b/mapproxy/scripts/mapproxify.py
@@ -56,6 +56,7 @@ DEFAULT_SERVICE_URL = os.environ.get('DEFAULT_SERVICE_URL', 'http://api3.geo.adm
 logger.info('Using %s service url.' % DEFAULT_SERVICE_URL)
 
 DEFAULT_EPSG_21781_ZOOM_LEVELS = 26
+STRETCH_FACTOR = 1.05
 
 DEFAULT_WMTS_BASE_URL = 'http://internal-vpc-lb-internal-wmts-infra-1291171036.eu-west-1.elb.amazonaws.com'
 
@@ -219,7 +220,7 @@ def create_grids(rng=[18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]):
            "bbox_srs": "EPSG:21781",
            "srs": "EPSG:21781",
            "origin": "nw",
-           "stretch_factor": 1.0
+           "stretch_factor": STRETCH_FACTOR
            }
 
     for i in rng:

--- a/mapproxy/templates/mapproxy.tpl
+++ b/mapproxy/templates/mapproxy.tpl
@@ -300,7 +300,7 @@ grids:
     bbox_srs: EPSG:2056
     srs: EPSG:2056
     origin: nw
-    stretch_factor: 1.0
+    stretch_factor: 1.05
 
 globals:
   cache:


### PR DESCRIPTION
During reprojection, mapproxy fails to choose a consistent tile level accrose whole of Switzerland:
![tiles](https://cloud.githubusercontent.com/assets/1236739/14563965/b4db376a-0324-11e6-963f-c0d5ee39e756.jpg)



[test link](http://wmts20.dev.bgdi.ch/demo/?wmts_layer=ch.swisstopo.pixelkarte-farbe_current_epsg_2056&format=jpeg&srs=EPSG%3A2056)