### PR TITLE
Fixing EPSG:2056

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ help:
 	@echo "- all              Install everything"
 	@echo "- mapproxy         Install and configure mapproxy"
 	@echo "- config           Configure mapproxy and create mapproxy.yaml (make config API_URL=http://mf-chsdi3.dev.bgdi.ch)"
+	@echo "- devconfig        Configure mapproxy and create mapproxy.yaml **without** S3 cache"
 	@echo "- apache           Configure Apache (restart required)"
 	@echo "- uwsgi            Install uwsgi"
 	@echo "- clean            Remove generated files"
@@ -64,6 +65,11 @@ apache: apache/app.conf
 .PHONY: config
 config: .build-artefacts/python-venv
 	${PYTHON_CMD} mapproxy/scripts/mapproxify.py $(API_URL)
+	touch $@
+
+.PHONY: devconfig
+devconfig: .build-artefacts/python-venv
+	env - API_URL="$$API_URL" WMTS_BASE_URL="$$WMTS_BASE_URL" ${PYTHON_CMD}  mapproxy/scripts/mapproxify.py $(API_URL)
 	touch $@
 
 .PHONY: mapproxy

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,12 @@ mapproxy: $(PYTHONVENV)/bin/mapproxy \
 .PHONY: uwsgi
 uwsgi: $(PYTHONVENV)/bin/uwsgi
 
+
+.PHONY: serve
+serve:
+	$(PYTHONVENV)/bin/mapproxy-util serve-develop -b 0.0.0.0:9001 --debug mapproxy/mapproxy.yaml
+
+
 .PHONY: diffdev
 diffdev:
 	if [ -z "$(MAPPROXY_CONFIG_BASE_PATH)" ] || [ -z "$(PROFILE_NAME)" ] ; \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MODWSGI_USER ?= $(shell id -un)
 API_URL ?= http://api3.geo.admin.ch
 PYTHONVENV ?= .build-artefacts/python-venv
 PYTHONVENV_OPTS ?=
-WMTS_BASE_URL ?= http://wmts6.geo.admin.ch
+WMTS_BASE_URL ?= http://s3-eu-west-1.amazonaws.com/akiai4jxkwjqv5tgsaoq-wmts
 MAPPROXY_CONFIG_BASE_PATH ?=swisstopo-internal-filesharing/config/mapproxy
 RANDOM_MAPPROXY_FILE="mapproxy.$$rand.yaml"
 export WMTS_BASE_URL

--- a/mapproxy/scripts/mapproxify.py
+++ b/mapproxy/scripts/mapproxify.py
@@ -237,14 +237,15 @@ def create_grids(epsg=21781, rng=[18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]):
     return grids
 
 
-def create_wmts_source(server_layer_name, timestamp):
+def create_wmts_source(server_layer_name, timestamp, wmts_source_grid):
     # original source (one for all projection)
+    # only epsg:21781, but different zoom levels 
     wmts_url = WMTS_BASE_URL + "/1.0.0/" + server_layer_name + \
         "/default/" + timestamp + "/21781/%(z)d/%(y)d/%(x)d.%(format)s"
 
     wmts_source = {"url": wmts_url,
                    "type": "tile",
-                   "grid": "swisstopo-pixelkarte",
+                   "grid": wmts_source_grid,
                    "transparent": True,
                    "on_error": {
                        204: {
@@ -339,9 +340,9 @@ def generate_mapproxy_config(layersConfigs, services=DEFAULT_SERVICES):
                             'values': [timestamp]}}
 
                     # original source (one for all projection)
-                    wmts_source = create_wmts_source(
-                        server_layer_name, timestamp)
                     wmts_source_grid = "epsg_21781_%s" % (max_level)
+                    wmts_source = create_wmts_source(
+                        server_layer_name, timestamp, wmts_source_grid)
 
                     wmts_cache = {
                         "sources": [wmts_source_name],
@@ -461,6 +462,11 @@ def main(service_url=DEFAULT_SERVICE_URL,
     print "Layers: %d, timestamps: %d" % (layers_nb, timestamps_nb)
     if USE_S3_CACHE:
         print "Using S3 cache: bucket=%s" % MAPPROXY_BUCKET_NAME
+    else: 
+        print
+        print "WARNING !!!!!"
+        print "Build WITHOUT S3 cache. Is it really want you want ?"
+        print
     if MAPPROXY_PROFILE_NAME:
         print "profile_name=%s" % MAPPROXY_PROFILE_NAME
         print "DO NOT DEPLOY THIS FILE.\nUsing profile will break the autoscaling cluster"


### PR DESCRIPTION
This should fixe https://github.com/geoadmin/service-mapproxy/issues/45

http://wmts20.int.bgdi.ch/demo/?wmts_layer=ch.swisstopo.pixelkarte-farbe_current_epsg_2056&format=jpeg&srs=EPSG%3A2056

compare with (zoom to the very latests zoom zoom level)

http://wmts20.prod.bgdi.ch/demo/?wmts_layer=ch.swisstopo.pixelkarte-farbe_current_epsg_2056&format=jpeg&srs=EPSG%3A2056

But bear in mind that  `ch.swisstopo.landeskarte-farbe-10` is originally LV95, converted into LV03 tiles, and back to LV95 with Mapproxy. This is a suboptimal solution.

Added also a few debugging goodies:
- More prominent WARNING if mapproxy.yaml is build without S3 cache
- `make serve` target 
- Abillity to create a `mapproxy.yaml`with only one or a few layers, to use debugging
- A pure development `mapproxy.yaml`without cache (`make devconfig`)
