### PR TITLE
Fix black border for some levels (EPS:2056)

### DIFF
--- a/mapproxy/templates/mapproxy.tpl
+++ b/mapproxy/templates/mapproxy.tpl
@@ -270,7 +270,6 @@ grids:
     base: GLOBAL_MERCATOR
     num_levels: 18
     origin: nw
-  #lowres_mercator:
   epsg_3857:
     base: GLOBAL_MERCATOR
     num_levels: 20
@@ -296,9 +295,10 @@ grids:
   #lowres_lv95:
   epsg_2056:
     res: [4000,3750,3500,3250,3000,2750,2500,2250,2000,1750,1500,1250,1000,750,650,500,250,100,50,20,10,5,2.5,2,1.5,1,0.5,0.25,0.1]
-    threshold_res: [900,700,400,200,90,40,15]
-    bbox: [2420000.0, 1030000.0, 2900000.0, 1350000.0]
-    bbox_srs: EPSG:2056
+    threshold_res: [900,700,400,200,90,40,15,7.5,3,1.8,1.3,0.75,0.4,0.15]
+    # Let Mapproxy do the bbox calculation
+    bbox: [420000.0, 030000.0, 900000.0, 350000.0]
+    bbox_srs: EPSG:21781
     srs: EPSG:2056
     origin: nw
     stretch_factor: 1.05


### PR DESCRIPTION
This PR fixes partially https://github.com/geoadmin/service-mapproxy/issues/48

This issue is due to the grid reprojection between LV03 and LV95, both projection are **very** close, and mapproxy's black magic has all sort of trouble with that.

Compare the improved version (no s3 cache), the first four zoom levels still display the black borders, at bigger scale it is better:

http://wmts20.int.bgdi.ch/demo/?wmts_layer=ch.swisstopo.swissimage_current_epsg_2056&format=jpeg&srs=EPSG%3A2056

With (prod)

http://wmts20.prod.bgdi.ch/demo/?wmts_layer=ch.swisstopo.swissimage_current_epsg_2056&format=jpeg&srs=EPSG%3A2056


**N.B.**
 We really need to solve this **another way**. The original `swissimage` are LV95. We export them as LV03 as base for WMTS tiles for geoadmin, which are in turn used as a source for WMTS epsg:2056 (reprojected back).
So, in the end, the tiles have been **reprojected and resampled twice**, which is not the best solution, in term of image quality and accuracy.



