### PR TITLE
Black borders (again)

### DIFF
--- a/mapproxy/scripts/mapproxify.py
+++ b/mapproxy/scripts/mapproxify.py
@@ -365,6 +365,7 @@ def generate_mapproxy_config(layersConfigs, services=DEFAULT_SERVICES):
                         #layer = {'name': layer_name, 'title': "%s (%s)" % (title, timestamp), 'dimensions': dimensions, 'sources': [cache_out_name]}
                         layer = {'name': layer_name, 'title': "%s (%s)" % (
                             title, timestamp), 'sources': [cache_out_name]}
+                        # For EPSG:2056, we should use a gutter as grid reprojection makes the tiles non-square
                         cache = {
                             "sources": [wmts_cache_name],
                             "format": "image/%s" %
@@ -374,7 +375,7 @@ def generate_mapproxy_config(layersConfigs, services=DEFAULT_SERVICES):
                             "meta_size": [
                                 1,
                                 1],
-                            "meta_buffer": 0}
+                            "meta_buffer": 0 if epsg_code != '2056' else 20}
                         if USE_S3_CACHE:
                             cache['disable_storage'] = False
 
@@ -387,7 +388,7 @@ def generate_mapproxy_config(layersConfigs, services=DEFAULT_SERVICES):
                             cache['cache'] = s3_cache
 
                         if '.swissimage' in wmts_cache_name:
-                            cache["image"] = {"resampling_method": "bilinear"}
+                            cache["image"] = {"resampling_method": "bicubic"}
                         elif '.swisstlm3d-karte' in wmts_cache_name:
                             cache["image"] = {"resampling_method": "nearest"}
 


### PR DESCRIPTION
See https://github.com/geoadmin/service-mapproxy/issues/48

As EPSG:2056 tiles are almost, but not identical to EPSG:21781 tiles, we should allow a bit more space. This will lead to more source tiles download (9), but it is the price to pay.

Demo link http://wmts20.int.bgdi.ch/demo/?wmts_layer=ch.swisstopo.swissimage_current666_epsg_2056&format=jpeg&srs=EPSG%3A2056