### PR TITLE
Deactivate all WMS requests

### DIFF
--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -19,3 +19,10 @@ location  /  {
     proxy_set_header x-forwarded-for $remote_addr;
     include uwsgi_params;
 }
+
+location ~ /service {
+    if ($args ~* "service=WMS") {
+        return 403;
+    }
+}
+


### PR DESCRIPTION
This PR deactivate all unwanted WMS request (see https://github.com/geoadmin/service-mapproxy/issues/51). 

This need a rebuild of the Mapproxy image used by the autoscaling groups.