### PR TITLE
Trying to improve performance for CWM

### DIFF
--- a/mapproxy/templates/mapproxy.tpl
+++ b/mapproxy/templates/mapproxy.tpl
@@ -79,7 +79,7 @@ sources:
     type: wms
     wms_opts:
       version: 1.1.1
-    supported_srs: ['EPSG:21781']
+    supported_srs: ['EPSG:2056']
     req:
       url: http://wms.cadastralwebmap.ch/WMS
       layers: cm_wms
@@ -134,7 +134,7 @@ caches:
     disable_storage: true
     format: image/png
     grids:
-    - epsg_21781
+    - epsg_2056
     sources:
     - ch.kantone.cadastralwebmap-farbe_wms_source
   ch.kantone.cadastralwebmap-farbe_epsg_21781_cache_out:


### PR DESCRIPTION
Since the switch to LV95 the original WMS server has "issue" with performance: requests with the same projection as underlying data (LV95) are less than stellar, requests with LV03 are very bad.

This PR tries to enhance performance in letting mapproxy doing the heavy duty reprojection (image reprojection though)

Demos

[original LV95 server](https://web-wmts-test.dev.bgdi.ch/?host_tpl=https%3A%2F%2Fwmts%7B20-24%7D.dev.bgdi.ch&raw_tpl=1&timestamp=current&use_src=0&format=png&layer=ch.kantone.cadastralwebmap-farbe&epsg=2056&lang=fr) nothing will be faster than this

[reprjection through original server](https://web-wmts-test.dev.bgdi.ch/?host_tpl=https%3A%2F%2Fwmts%7B20-24%7D.prod.bgdi.ch&raw_tpl=1&timestamp=current&use_src=0&format=png&layer=ch.kantone.cadastralwebmap-farbe&epsg=21781&lang=fr)

[reprojection through mapproxy](https://web-wmts-test.dev.bgdi.ch/?host_tpl=https%3A%2F%2Fwmts%7B20-24%7D.dev.bgdi.ch&raw_tpl=1&timestamp=current&use_src=0&format=png&layer=ch.kantone.cadastralwebmap-farbe&epsg=21781&lang=fr) This PR

